### PR TITLE
feat(greedy bot): Allow use of alternative token symbol for price lookup

### DIFF
--- a/packages/bot-taker-greedy/README.md
+++ b/packages/bot-taker-greedy/README.md
@@ -83,7 +83,9 @@ Here's an example configuration file with instances of all possible configuratio
   - `targetAllowance`: The allowance that Mangrove should be approved to transfer on behalf of the bot. On startup, this is checked and an approval tx sent if the current approval is too low.
 - `markets`: A list of per-market configurations. The bot will take offers from each of the markets listed here.
   - `baseToken`: The symbol of the base token.
+  - `baseTokenSymbolForPriceLookup?` Optional symbol to use instead of `baseToken` when looking up prices (eg MATIC instead of WMATIC). Useful if `baseToken` is not listed.
   - `quoteToken`: The symbol of the quote token.
+  - `quoteTokenSymbolForPriceLookup?` Optional symbol to use instead of `quoteToken` when looking up prices (eg MATIC instead of WMATIC). Useful if `quoteToken` is not listed.
   - `takerConfig`: Configuration of the taker on this market:
     - `sleepTimeMilliseconds`: The number of milliseconds the bot should sleep in between checking the market.
     - `offerCountCap`: The max number of offers the bot should attempt to take.

--- a/packages/bot-taker-greedy/config/default.json
+++ b/packages/bot-taker-greedy/config/default.json
@@ -38,6 +38,15 @@
         "sleepTimeMilliseconds": 30000,
         "offerCountCap": 5
       }
+    },
+    {
+      "baseToken": "WMATIC",
+      "baseTokenSymbolForPriceLookup": "MATIC",
+      "quoteToken": "USDT",
+      "takerConfig": {
+        "sleepTimeMilliseconds": 30000,
+        "offerCountCap": 5
+      }
     }
   ]
 }

--- a/packages/bot-taker-greedy/src/MarketConfig.ts
+++ b/packages/bot-taker-greedy/src/MarketConfig.ts
@@ -5,6 +5,8 @@ export type TakerConfig = {
 
 export type MarketConfig = {
   baseToken: string;
+  baseTokenSymbolForPriceLookup?: string; // Allow use of another symbol when looking up a price an unlisted token (eg MATIC instead for WMATIC)
   quoteToken: string;
+  quoteTokenSymbolForPriceLookup?: string; // Same as baseTokenSymbolForPriceLookup
   takerConfig: TakerConfig;
 };

--- a/packages/bot-taker-greedy/src/OfferTaker.ts
+++ b/packages/bot-taker-greedy/src/OfferTaker.ts
@@ -1,6 +1,6 @@
 import { logger } from "./util/logger";
 import { Market } from "@mangrovedao/mangrove.js";
-import { TakerConfig } from "./MarketConfig";
+import { MarketConfig, TakerConfig } from "./MarketConfig";
 import { fetchJson } from "ethers/lib/utils";
 import { ToadScheduler, SimpleIntervalJob, AsyncTask } from "toad-scheduler";
 import Big from "big.js";
@@ -28,6 +28,7 @@ export class OfferTaker {
    */
   constructor(
     market: Market,
+    marketConfig: MarketConfig,
     takerAddress: string,
     takerConfig: TakerConfig,
     scheduler: ToadScheduler
@@ -36,8 +37,10 @@ export class OfferTaker {
     this.#takerAddress = takerAddress;
     this.#takerConfig = takerConfig;
     this.#cryptoCompareUrl = `https://min-api.cryptocompare.com/data/price?fsym=${
-      this.#market.base.name
-    }&tsyms=${this.#market.quote.name}`;
+      marketConfig.baseTokenSymbolForPriceLookup ?? this.#market.base.name
+    }&tsyms=${
+      marketConfig.quoteTokenSymbolForPriceLookup ?? this.#market.quote.name
+    }`;
     this.#scheduler = scheduler;
 
     logger.info("Initalized offer taker", {

--- a/packages/bot-taker-greedy/src/index.ts
+++ b/packages/bot-taker-greedy/src/index.ts
@@ -48,6 +48,7 @@ async function startTakersForMarkets(
 
     const offerTaker = new OfferTaker(
       market,
+      marketConfig,
       address,
       marketConfig.takerConfig,
       scheduler


### PR DESCRIPTION
CryptoCompare does not support WMATIC in price lookups. We therefore add a feature, where the market configuration can specify an alternative token symbol (eg MATIC) to use in the price lookup.