### PR TITLE
fix: bot-cleaner test uses fee overrides

### DIFF
--- a/packages/bot-utils/src/util/txUtils.ts
+++ b/packages/bot-utils/src/util/txUtils.ts
@@ -15,22 +15,29 @@ const PolygonOverrides = {
 };
 
 export class TxUtils {
-  private logger: CommonLogger;
-  private provider: ethers.providers.Provider;
+  private logger?: CommonLogger;
+  private provider?: ethers.providers.Provider;
 
-  constructor(provider: ethers.providers.Provider, logger: CommonLogger) {
+  constructor(provider?: ethers.providers.Provider, logger?: CommonLogger) {
     this.logger = logger;
     this.provider = provider;
   }
 
-  public async getFeeOverrides(): Promise<Fees | undefined> {
+  public async getFeeOverrides(chainId?: Number): Promise<Fees | undefined> {
     let maxFeePerGas;
     let maxPriorityFeePerGas;
 
-    const chainId = (await this.provider.getNetwork()).chainId;
+    if (!chainId && !this.provider) {
+      this.logger?.error(
+        "No `chainId` given and no provider available to get chainId."
+      );
+      return undefined;
+    }
+    const chainIdToQuery =
+      chainId || (await this.provider!.getNetwork()).chainId;
 
     // special case Polygon Mainnet, as required fees are underestimated by ethers.js - see https://github.com/ethers-io/ethers.js/issues/2828
-    if (chainId === 137) {
+    if (chainIdToQuery === 137) {
       // default values for fees - these are used if the gasstation is not reachable
 
       try {
@@ -49,7 +56,7 @@ export class TxUtils {
           "gwei"
         );
 
-        this.logger.debug("Fees via Polygon Gasstation", {
+        this.logger?.debug("Fees via Polygon Gasstation", {
           data: { maxFeePerGas, maxPriorityFeePerGas },
         });
 
@@ -61,13 +68,13 @@ export class TxUtils {
         // fall back to defaults
         maxFeePerGas = PolygonOverrides.maxFeePerGas;
         maxPriorityFeePerGas = PolygonOverrides.maxPriorityFeePerGas;
-        this.logger.debug(
+        this.logger?.debug(
           "Error in contacting Polygon gasstation - falling back to default fees",
           { data: { maxFeePerGas, maxPriorityFeePerGas } }
         );
       }
     } else {
-      this.logger.debug("No overrides of fees registered needed.");
+      this.logger?.debug("No overrides of fees registered needed.");
     }
     return undefined;
   }

--- a/packages/bot-utils/test/integration/botUtils.integration.test.ts
+++ b/packages/bot-utils/test/integration/botUtils.integration.test.ts
@@ -1,6 +1,25 @@
+import { expect } from "chai";
 import { describe, it } from "mocha";
+import { TxUtils } from "../../src";
 
 describe("Bot utils tests", () => {
-  //Replace with real tests.
-  it(" empty test", async function () {});
+  const PolygonChainId = 137;
+  const MumbaiChainId = 80001;
+
+  it("txUtils.GetFeeOverrides returns overriding fee for Polygon", async function () {
+    const txUtils = new TxUtils();
+    const fees = await txUtils.getFeeOverrides(PolygonChainId);
+
+    return Promise.all([
+      expect(fees).to.have.property("maxFeePerGas"),
+      expect(fees).to.have.property("maxPriorityFeePerGas"),
+    ]);
+  });
+
+  it("txUtils.GetFeeOverrides returns no overrriding fee for Mumbai", async function () {
+    const txUtils = new TxUtils();
+    const fees = await txUtils.getFeeOverrides(MumbaiChainId);
+
+    return Promise.all([expect(fees).to.be.undefined]);
+  });
 });

--- a/packages/bot-utils/tsconfig.json
+++ b/packages/bot-utils/tsconfig.json
@@ -12,7 +12,7 @@
     "outDir": "build",
     "baseUrl": ".",
     "paths": {
-      "*": ["node_modules/*"]
+      "*": ["node_modules/*", "src/types/*"]
     },
     "composite": true,
     "rootDir": "src/"


### PR DESCRIPTION
Also add integration test for txUtils to get early warning if gasstation is down.