### PR TITLE
Hotfix - use chainid to get Alchemy network in price utils

### DIFF
--- a/packages/bot-arbitrage/src/ArbBot.ts
+++ b/packages/bot-arbitrage/src/ArbBot.ts
@@ -30,6 +30,10 @@ export class ArbBot {
     try {
       const [base, quote, fee] = marketConfig;
 
+      if (!this.mgv.network.id) {
+        throw new Error("No network id found for mangrove.");
+      }
+
       const API_KEY = process.env["API_KEY"];
       let gasprice: BigNumber;
       if (!API_KEY) {
@@ -42,7 +46,7 @@ export class ArbBot {
       } else {
         gasprice = await this.priceUtils.getGasPrice(
           API_KEY,
-          this.mgv.network.name
+          this.mgv.network.id!
         );
       }
       const nativeToken = this.getNativeTokenNameAndDecimals(

--- a/packages/bot-updategas/config/custom-environment-variables.json
+++ b/packages/bot-updategas/config/custom-environment-variables.json
@@ -8,7 +8,6 @@
     "__name": "CONSTANT_ORACLE_GAS_PRICE",
     "__format": "number"
   },
-  "network": "NETWORK",
   "runEveryXHours": {
     "__name": "RUN_EVERY_X_HOURS",
     "__format": "number"

--- a/packages/bot-updategas/config/default.json
+++ b/packages/bot-updategas/config/default.json
@@ -1,7 +1,6 @@
 {
   "logLevel": "debug",
   "acceptableGasGapToOracle": 0.5,
-  "network": "MATIC_MUMBAI",
   "maxUpdateConstraint": {},
   "runEveryXHours": 8
 }

--- a/packages/bot-updategas/config/test.json
+++ b/packages/bot-updategas/config/test.json
@@ -2,7 +2,6 @@
   "logLevel": "debug",
   "acceptableGasGapToOracle": 0.5,
   "constantOracleGasPrice": 6,
-  "network": "MATIC_MUMBAI",
   "runEveryXHours": 0.008,
   "maxUpdateConstraint": {
     "constant": 10

--- a/packages/bot-updategas/src/GasHelper.ts
+++ b/packages/bot-updategas/src/GasHelper.ts
@@ -15,7 +15,6 @@ class GasHelper {
    */
   async getGasPriceEstimateFromOracle(params: {
     constantGasPrice: number | undefined;
-    network: string;
     mangrove: Mangrove;
   }): Promise<number | undefined> {
     if (params.constantGasPrice !== undefined) {
@@ -25,13 +24,18 @@ class GasHelper {
       );
       return params.constantGasPrice;
     }
+
+    if (!params.mangrove.network.id) {
+      throw new Error("No network id found for mangrove.");
+    }
+
     const API_KEY = process.env["API_KEY"];
     if (!API_KEY) {
       throw new Error("No API key for alchemy");
     }
 
     const gaspriceFromOracle = this.priceUtils
-      .getGasPrice(API_KEY, params.network)
+      .getGasPrice(API_KEY, params.mangrove.network.id)
       .then((gaspriceEstimateInWei) => {
         const gasPriceEstimateInGwei = ethers.utils.formatUnits(
           gaspriceEstimateInWei,

--- a/packages/bot-updategas/src/GasHelper.ts
+++ b/packages/bot-updategas/src/GasHelper.ts
@@ -30,7 +30,7 @@ class GasHelper {
       throw new Error("No API key for alchemy");
     }
 
-    return this.priceUtils
+    const gaspriceFromOracle = this.priceUtils
       .getGasPrice(API_KEY, params.network)
       .then((gaspriceEstimateInWei) => {
         const gasPriceEstimateInGwei = ethers.utils.formatUnits(
@@ -46,6 +46,12 @@ class GasHelper {
         });
         return undefined;
       });
+
+    logger.debug("Gas price estimate received from oracle", {
+      data: gaspriceFromOracle,
+    });
+
+    return gaspriceFromOracle;
   }
 
   /**

--- a/packages/bot-updategas/src/util/config.ts
+++ b/packages/bot-updategas/src/util/config.ts
@@ -1,6 +1,11 @@
 import config from "config";
 import dotenvFlow from "dotenv-flow";
-import { MaxUpdateConstraint, OracleSourceConfiguration } from "../GasUpdater";
+import {
+  MaxUpdateConstraint,
+  OracleSourceConfiguration,
+  AlchemySDKConfiguration,
+  ConstantOracleConfiguration,
+} from "../GasUpdater";
 import logger from "./logger";
 dotenvFlow.config();
 if (!process.env["NODE_CONFIG_DIR"]) {
@@ -73,31 +78,18 @@ export function readAndValidateConfig(): OracleConfig {
     oracleSourceConfiguration = {
       OracleGasPrice: constantOracleGasPrice,
       _tag: "Constant",
-    };
+    } as ConstantOracleConfiguration;
   } else {
-    // basic validatation of endpoint config
-    if (network == null || network == "") {
-      configErrors.push(
-        `Either 'constantOracleGasPrice' or network must be set in config. Found values: constantOracleGasPrice: '${constantOracleGasPrice}', network: '${network}'}'`
-      );
-    }
+    oracleSourceConfiguration = {} as AlchemySDKConfiguration;
     logger.info(
-      `Configuration for oracle endpoint found. Using the configured values.`,
-      {
-        data: { network },
-      }
+      `No configuration for constant oracle gas price found. Using Alchemy as oracle for gas prices.`
     );
+  }
 
-    if (configErrors.length > 0) {
-      throw new Error(
-        `Found following config errors: [${configErrors.join(", ")}]`
-      );
-    }
-
-    oracleSourceConfiguration = {
-      network: network,
-      _tag: "Endpoint",
-    };
+  if (configErrors.length > 0) {
+    throw new Error(
+      `Found following config errors: [${configErrors.join(", ")}]`
+    );
   }
 
   return {

--- a/packages/bot-updategas/test/unit/gasHelper.unit.test.ts
+++ b/packages/bot-updategas/test/unit/gasHelper.unit.test.ts
@@ -24,7 +24,6 @@ describe("GasHelper unit test suite", () => {
       //Act
       const result = await gasHelper.getGasPriceEstimateFromOracle({
         constantGasPrice: constantGasPrice,
-        network: "polygon-mumbai",
         mangrove: instance(mangrove),
       });
 

--- a/packages/bot-utils/src/util/priceUtils.ts
+++ b/packages/bot-utils/src/util/priceUtils.ts
@@ -131,25 +131,45 @@ export class PriceUtils {
   }
 
   /**
+   * Get the Alchemy network corresponding to the chainId.
+   *
+   * @param chainId the chainId of the network to query
+   * @returns the Alchemy network corresponding to the chainId
+   * @remarks One should think that Alchemy provided a method (or an overload of the Alchemy constructor) to do this, but I haven't been able to find it.
+   */
+  getAlchemyNetworkFromChainId(chainId: number): Network | undefined {
+    switch (chainId) {
+      case 137:
+        return Network.MATIC_MAINNET;
+      case 80001:
+        return Network.MATIC_MUMBAI;
+      case 1:
+        return Network.ETH_MAINNET;
+      case 5:
+        return Network.ETH_GOERLI;
+    }
+
+    return undefined;
+  }
+
+  /**
    * Queries the alchemy node for the current gas price.
    * @param APIKEY An API key for alchemy node
-   * @param network The network key (see Network in alchemy-sdk for more info)
+   * @param chainId the chainId of the network to query
    * @returns the best guess of the current gas price to use in transactions
    */
-  public async getGasPrice(APIKEY: string, network: string) {
-    const networkIndex = Object.entries(Network).find(
-      (item) => item[0] === network.toUpperCase()
-    );
+  public async getGasPrice(APIKEY: string, chainId: number) {
+    const alchemyNetwork = this.getAlchemyNetworkFromChainId(chainId);
 
-    if (!networkIndex) {
+    if (!alchemyNetwork) {
       throw new Error(
-        `Given network: ${network}, is not in the alchemy networks`
+        `Cannot find Alchemy network corresponding to chainId: ${chainId}.`
       );
     }
 
     const alchemy = new Alchemy({
       apiKey: APIKEY,
-      network: networkIndex[1],
+      network: alchemyNetwork,
     });
 
     return await alchemy.core.getGasPrice();

--- a/packages/bot-utils/src/util/priceUtils.ts
+++ b/packages/bot-utils/src/util/priceUtils.ts
@@ -1,13 +1,13 @@
 import { CommonLogger } from "../logging/coreLogger";
-import { Market } from "@mangrovedao/mangrove.js";
+import { ethers, Market } from "@mangrovedao/mangrove.js";
 import Big from "big.js";
 import { fetchJson } from "ethers/lib/utils";
 import random from "random";
 import { Network, Alchemy } from "alchemy-sdk";
 
 export class PriceUtils {
-  logger: CommonLogger;
-  constructor(_logger: CommonLogger) {
+  logger?: CommonLogger;
+  constructor(_logger?: CommonLogger) {
     this.logger = _logger;
   }
 
@@ -51,7 +51,7 @@ export class PriceUtils {
       market.quote.name
     );
     try {
-      this.logger.debug("Getting external price reference", {
+      this.logger?.debug("Getting external price reference", {
         contextInfo: "maker",
         base: market.base.name,
         quote: market.quote.name,
@@ -63,7 +63,7 @@ export class PriceUtils {
       const price = await externalPrice.price();
       if (price !== undefined) {
         const referencePrice = price;
-        this.logger.info(
+        this.logger?.info(
           "Using external price reference as order book is empty",
           {
             contextInfo: "maker",
@@ -79,7 +79,7 @@ export class PriceUtils {
         return referencePrice;
       }
 
-      this.logger.warn(
+      this.logger?.warn(
         `Response did not contain a ${market.quote.name} field`,
         {
           contextInfo: "maker",
@@ -95,7 +95,7 @@ export class PriceUtils {
 
       return;
     } catch (e) {
-      this.logger.error(`Error encountered while fetching external price`, {
+      this.logger?.error(`Error encountered while fetching external price`, {
         contextInfo: "maker",
         base: market.base.name,
         quote: market.quote.name,
@@ -116,7 +116,7 @@ export class PriceUtils {
     let bestOffer: Market.Offer | undefined = undefined;
     if (offerList.length > 0) {
       bestOffer = offerList[0];
-      this.logger.debug("Best offer on book", {
+      this.logger?.debug("Best offer on book", {
         contextInfo: "maker",
         base: market.base.name,
         quote: market.quote.name,
@@ -130,10 +130,17 @@ export class PriceUtils {
     await this.getExternalPrice(market, ba);
   }
 
+  /**
+   * Queries the alchemy node for the current gas price.
+   * @param APIKEY An API key for alchemy node
+   * @param network The network key (see Network in alchemy-sdk for more info)
+   * @returns the best guess of the current gas price to use in transactions
+   */
   public async getGasPrice(APIKEY: string, network: string) {
-    const networkIndex = Object.entries(Network).find((item) =>
-      item[0].includes(network.toUpperCase())
+    const networkIndex = Object.entries(Network).find(
+      (item) => item[0] === network.toUpperCase()
     );
+
     if (!networkIndex) {
       throw new Error(
         `Given network: ${network}, is not in the alchemy networks`

--- a/packages/bot-utils/src/util/priceUtils.ts
+++ b/packages/bot-utils/src/util/priceUtils.ts
@@ -1,5 +1,5 @@
 import { CommonLogger } from "../logging/coreLogger";
-import { ethers, Market } from "@mangrovedao/mangrove.js";
+import { Market } from "@mangrovedao/mangrove.js";
 import Big from "big.js";
 import { fetchJson } from "ethers/lib/utils";
 import random from "random";

--- a/packages/bot-utils/test/unit/botUtils.unit.test.ts
+++ b/packages/bot-utils/test/unit/botUtils.unit.test.ts
@@ -10,7 +10,7 @@ describe("Unit test suite for bot utils", () => {
     const priceUtils = new PriceUtils();
 
     return expect(
-      priceUtils.getGasPrice("NO_API_KEY", "unknown-network")
+      priceUtils.getGasPrice("NO_API_KEY", 9999)
     ).to.eventually.be.rejectedWith(Error);
   });
 });

--- a/packages/bot-utils/test/unit/botUtils.unit.test.ts
+++ b/packages/bot-utils/test/unit/botUtils.unit.test.ts
@@ -9,8 +9,8 @@ describe("Unit test suite for bot utils", () => {
   it("priceUtils.getGasPrice throws on unknown network", async function () {
     const priceUtils = new PriceUtils();
 
-    expect(
+    return expect(
       priceUtils.getGasPrice("NO_API_KEY", "unknown-network")
-    ).to.eventually.be.rejectedWith("Unknown-network");
+    ).to.eventually.be.rejectedWith(Error);
   });
 });

--- a/packages/bot-utils/test/unit/botUtils.unit.test.ts
+++ b/packages/bot-utils/test/unit/botUtils.unit.test.ts
@@ -1,5 +1,16 @@
+import * as chai from "chai";
+const { expect } = chai;
+import chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
 import { describe, it } from "mocha";
+import { PriceUtils } from "../../src";
 
 describe("Unit test suite for bot utils", () => {
-  //Write tests here
+  it("priceUtils.getGasPrice throws on unknown network", async function () {
+    const priceUtils = new PriceUtils();
+
+    expect(
+      priceUtils.getGasPrice("NO_API_KEY", "unknown-network")
+    ).to.eventually.be.rejectedWith("Unknown-network");
+  });
 });


### PR DESCRIPTION
This change also ends up removing some superfluous configuration in updategas-bot. 