### PR TITLE
chore(deps): Bump mangrove.js to 1.4.2

### DIFF
--- a/packages/bot-utils/package.json
+++ b/packages/bot-utils/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@ethersproject/experimental": "^5.7.0",
-    "@mangrovedao/mangrove.js": "^1.4.1",
+    "@mangrovedao/mangrove.js": "^1.4.2",
     "@types/big.js": "^6.1.6",
     "@types/express": "^4.17.17",
     "@types/finalhandler": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,7 +1279,7 @@ __metadata:
     "@espendk/json-file-reporter": ^1.4.2
     "@ethersproject/experimental": ^5.7.0
     "@ethersproject/hardware-wallets": ^5.7.0
-    "@mangrovedao/mangrove.js": ^1.4.1
+    "@mangrovedao/mangrove.js": ^1.4.2
     "@types/big.js": ^6.1.6
     "@types/chai": ^4.3.4
     "@types/chai-as-promised": ^7.1.5
@@ -1349,13 +1349,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mangrovedao/mangrove.js@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "@mangrovedao/mangrove.js@npm:1.4.1"
+"@mangrovedao/mangrove.js@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@mangrovedao/mangrove.js@npm:1.4.2"
   dependencies:
     "@ethersproject/experimental": ^5.7.0
     "@mangrovedao/mangrove-core": 1.5.4
-    "@mangrovedao/reliable-event-subscriber": 1.1.19
+    "@mangrovedao/reliable-event-subscriber": 1.1.21
     "@types/object-inspect": ^1.8.1
     "@types/triple-beam": ^1.3.2
     async-mutex: ^0.4.0
@@ -1373,13 +1373,13 @@ __metadata:
     yargs: ^17.3.0
   bin:
     mgv: ./dist/nodejs/cli/mgv.js
-  checksum: 567dcc52b651c1de4abbc51466a0749aa3fe8d306d6c05df85367a5f84abaaccceb8923540f1c3831c2ba03dd2c358f46407306d6ef85dacb08ebdc975cb1307
+  checksum: c77921594811772cd8e220e95da5e79b32c2cab3b4e739f9fc5e2a6842ef6d573db39d749a15e7a44915ac5b3a029ccb72745d9cd9a3053c9596c647edeb42d8
   languageName: node
   linkType: hard
 
-"@mangrovedao/reliable-event-subscriber@npm:1.1.19":
-  version: 1.1.19
-  resolution: "@mangrovedao/reliable-event-subscriber@npm:1.1.19"
+"@mangrovedao/reliable-event-subscriber@npm:1.1.21":
+  version: 1.1.21
+  resolution: "@mangrovedao/reliable-event-subscriber@npm:1.1.21"
   dependencies:
     "@ethersproject/providers": ^5.7.2
     async-mutex: ^0.4.0
@@ -1387,7 +1387,7 @@ __metadata:
     ethers: ^5.7.2
     isomorphic-ws: ^5.0.0
     ws: ^8.13.0
-  checksum: 936f39d69bafc5d3e3e325f5f78cdaa4238171072933c7dc80c0c9d07d5cacd3f9fa2cc17493f1661211b2e7502a7b684c1d1bf52e3a7bfdef5b2efc2458c4cc
+  checksum: 7c88408203cff29cbff47a9eb224a24bdb74ecb5ba298d466d892f7eedf0d96811570426e77e2d48326e5195b439a4197ff58d6c5f66737f130b1f32f67dad7d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Includes RES logging improvements